### PR TITLE
bugfix-6: allByClassName selector fixed

### DIFF
--- a/src/wdio/browser.ts
+++ b/src/wdio/browser.ts
@@ -47,7 +47,7 @@ export class Browser {
     }
 
     public static allByClassName(className: string): ElementArrayFinder {
-        return new ElementArrayFinder({type: LocatorType.ArraySelector, selector: `${className}`});
+        return new ElementArrayFinder({type: LocatorType.ArraySelector, selector: `.${className}`});
     }
 
     public static allByCSS(cssExpression: string): ElementArrayFinder {

--- a/src/wdio/element-finder.ts
+++ b/src/wdio/element-finder.ts
@@ -42,7 +42,7 @@ export class ElementFinder {
     }
 
     public allByClassName(className: string): ElementArrayFinder {
-        return new ElementArrayFinder({type: LocatorType.ArraySelector, selector: `${className}`}, this);
+        return new ElementArrayFinder({type: LocatorType.ArraySelector, selector: `.${className}`}, this);
     }
 
     public allByCSS(cssExpression: string): ElementArrayFinder {


### PR DESCRIPTION
# PR Details
Fix the allByClassName methods

## Description
Added "." to prefix the className inside the selector of the allByClassName methods

## Related Issue
https://github.com/systelab/systelab-components-wdio-test/issues/6

## Motivation and Context
Bug found when trying to call the affected methods from my project's components

## How Has This Been Tested
-

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] I have added tests to cover my changes (at least 1 spec for each widget with the same coverage as the master branch)
- [ ] All tests (new and existing) passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
