### PR TITLE
Bugfix 19: Wait until loaded method of grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/pages/base-page.ts
+++ b/src/pages/base-page.ts
@@ -13,6 +13,14 @@ export class BasePage {
         return this.current;
     }
 
+    public async isPresent(): Promise<boolean> {
+        return this.current.isPresent();
+    }
+
+    public async isDisplayed(): Promise<boolean> {
+        return this.current.isDisplayed();
+    }
+
     public byId(id: string): ElementFinder {
         return this.current.byId(id);
     }
@@ -50,6 +58,18 @@ export class BasePage {
     }
 
     public async waitToBePresent(timeout: number = 5000): Promise<void> {
-        return this.current.waitToBePresent(timeout);
+        return this.current.waitUntil(async () => await this.isPresent(), timeout);
+    }
+
+    public async waitToBeNotPresent(timeout: number = 5000): Promise<void> {
+        return this.current.waitUntil(async () => !(await this.isPresent()), timeout);
+    }
+
+    public async waitToBeDisplayed(timeout: number = 5000): Promise<void> {
+        return this.current.waitUntil(async () => await this.isDisplayed(), timeout);
+    }
+
+    public async waitToBeNotDisplayed(timeout: number = 5000): Promise<void> {
+        return this.current.waitUntil(async () => !(await this.isDisplayed()), timeout);
     }
 }

--- a/src/pages/base-page.ts
+++ b/src/pages/base-page.ts
@@ -1,4 +1,4 @@
-import { Browser, ElementArrayFinder, ElementFinder } from "../wdio";
+import { Browser, DefaultTimeout, ElementArrayFinder, ElementFinder } from "../wdio";
 
 
 export class BasePage {
@@ -57,19 +57,19 @@ export class BasePage {
         return this.current.allByCSS(cssExpression);
     }
 
-    public async waitToBePresent(timeout: number = 5000): Promise<void> {
+    public async waitToBePresent(timeout: number = DefaultTimeout.SLOW_WAIT): Promise<void> {
         return this.current.waitUntil(async () => await this.isPresent(), timeout);
     }
 
-    public async waitToBeNotPresent(timeout: number = 5000): Promise<void> {
+    public async waitToBeNotPresent(timeout: number = DefaultTimeout.SLOW_WAIT): Promise<void> {
         return this.current.waitUntil(async () => !(await this.isPresent()), timeout);
     }
 
-    public async waitToBeDisplayed(timeout: number = 5000): Promise<void> {
+    public async waitToBeDisplayed(timeout: number = DefaultTimeout.SLOW_WAIT): Promise<void> {
         return this.current.waitUntil(async () => await this.isDisplayed(), timeout);
     }
 
-    public async waitToBeNotDisplayed(timeout: number = 5000): Promise<void> {
+    public async waitToBeNotDisplayed(timeout: number = DefaultTimeout.SLOW_WAIT): Promise<void> {
         return this.current.waitUntil(async () => !(await this.isDisplayed()), timeout);
     }
 }

--- a/src/wdio/browser.ts
+++ b/src/wdio/browser.ts
@@ -55,7 +55,11 @@ export class Browser {
     }
 
 
-    // Condition waits
+    // Flow control
+    public static async sleep(duration: number): Promise<void> {
+        await browser.pause(duration);
+    }
+
     public static async waitUntil(condition: () => boolean | Promise<boolean>, timeout: number = 5000): Promise<void> {
         await browser.waitUntil(condition, {timeout});
     }

--- a/src/wdio/browser.ts
+++ b/src/wdio/browser.ts
@@ -1,5 +1,7 @@
 import { LocatorType } from "./locator";
 import { ElementFinder, ElementArrayFinder } from "./element-finder";
+import { DefaultTimeout } from "./default-timeout";
+
 
 export class Browser {
 
@@ -60,7 +62,7 @@ export class Browser {
         await browser.pause(duration);
     }
 
-    public static async waitUntil(condition: () => boolean | Promise<boolean>, timeout: number = 5000): Promise<void> {
+    public static async waitUntil(condition: () => boolean | Promise<boolean>, timeout: number = DefaultTimeout.SLOW_WAIT): Promise<void> {
         await browser.waitUntil(condition, {timeout});
     }
 }

--- a/src/wdio/default-timeout.ts
+++ b/src/wdio/default-timeout.ts
@@ -1,0 +1,5 @@
+
+export class DefaultTimeout {
+    public static readonly FAST_WAIT: number = 500;
+    public static readonly SLOW_WAIT: number = 5000;
+}

--- a/src/wdio/index.ts
+++ b/src/wdio/index.ts
@@ -1,3 +1,4 @@
 export * from './browser';
+export * from './default-timeout';
 export * from './element-finder';
 export * from './locator';

--- a/src/widgets/grid.ts
+++ b/src/widgets/grid.ts
@@ -1,15 +1,9 @@
-import { ElementArrayFinder, ElementFinder } from "../wdio";
+import { DefaultTimeout, ElementArrayFinder, ElementFinder } from "../wdio";
 import { ContextMenu } from './context-menu';
 import { Widget } from './widget';
 
 
 export class Grid extends Widget {
-    public async waitUntilLoaded(loadingCSSSelector: string = ".ag-overlay-loading-wrapper", timeout: number = 5000) {
-        return this.elem.waitUntil(async () => {
-            return !this.byCSS(loadingCSSSelector).isDisplayed();
-        }, timeout);
-    }
-
     public async getNumberOfRows(): Promise<number> {
         return this.byCSS('.ag-center-cols-container').allByCSS('div[role=row]').count();
     }
@@ -86,6 +80,10 @@ export class Grid extends Widget {
 
     public getMenu(): ContextMenu {
         return new ContextMenu(this.byTagName('systelab-grid-context-menu'));
+    }
+
+    public async waitToBeLoaded({loadingOverlayCSSSelector= '.ag-overlay-loading-wrapper', timeout = DefaultTimeout.SLOW_WAIT}) {
+        return this.elem.waitUntil(async () => !(await this.byCSS(loadingOverlayCSSSelector).isDisplayed()), timeout);
     }
 
     private getCells(container: ElementFinder, row: number, column: string): ElementArrayFinder {

--- a/src/widgets/widget.ts
+++ b/src/widgets/widget.ts
@@ -1,4 +1,4 @@
-import { ElementArrayFinder, ElementFinder } from "../wdio";
+import { ElementArrayFinder, ElementFinder, DefaultTimeout } from "../wdio";
 
 
 export class Widget {
@@ -66,39 +66,39 @@ export class Widget {
         return this.elem.allByCSS(cssExpression);
     }
 
-    public async waitToBePresent(timeout: number = 500): Promise<void> {
+    public async waitToBePresent(timeout: number = DefaultTimeout.FAST_WAIT): Promise<void> {
         return this.elem.waitUntil(async () => await this.isPresent(), timeout);
     }
 
-    public async waitToBeNotPresent(timeout: number = 500): Promise<void> {
+    public async waitToBeNotPresent(timeout: number = DefaultTimeout.FAST_WAIT): Promise<void> {
         return this.elem.waitUntil(async () => !(await this.isPresent()), timeout);
     }
 
-    public async waitToBeDisplayed(timeout: number = 500): Promise<void> {
+    public async waitToBeDisplayed(timeout: number = DefaultTimeout.FAST_WAIT): Promise<void> {
         return this.elem.waitUntil(async () => await this.isDisplayed(), timeout);
     }
 
-    public async waitToBeNotDisplayed(timeout: number = 500): Promise<void> {
+    public async waitToBeNotDisplayed(timeout: number = DefaultTimeout.FAST_WAIT): Promise<void> {
         return this.elem.waitUntil(async () => !(await this.isDisplayed()), timeout);
     }
 
-    public async waitToBeClickable(timeout: number = 500): Promise<void> {
+    public async waitToBeClickable(timeout: number = DefaultTimeout.FAST_WAIT): Promise<void> {
         return this.elem.waitUntil(async () => await this.isClickable(), timeout);
     }
 
-    public async waitToBeNotClickable(timeout: number = 500): Promise<void> {
+    public async waitToBeNotClickable(timeout: number = DefaultTimeout.FAST_WAIT): Promise<void> {
         return this.elem.waitUntil(async () => !(await this.isClickable()), timeout);
     }
 
-    public async waitToBeEnabled(timeout: number = 500): Promise<void> {
+    public async waitToBeEnabled(timeout: number = DefaultTimeout.FAST_WAIT): Promise<void> {
         return this.elem.waitUntil(async () => await this.isEnabled(), timeout);
     }
 
-    public async waitToBeDisabled(timeout: number = 500): Promise<void> {
+    public async waitToBeDisabled(timeout: number = DefaultTimeout.FAST_WAIT): Promise<void> {
         return this.elem.waitUntil(async () => await this.isDisabled(), timeout);
     }
 
-    public async waitUntil(condition: () => boolean | Promise<boolean>, timeout: number = 5000): Promise<void> {
+    public async waitUntil(condition: () => boolean | Promise<boolean>, timeout: number = DefaultTimeout.SLOW_WAIT): Promise<void> {
         return this.elem.waitUntil(condition, timeout);
     }
 }

--- a/src/widgets/widget.ts
+++ b/src/widgets/widget.ts
@@ -27,7 +27,7 @@ export class Widget {
     }
 
     public async isDisabled(): Promise<boolean> {
-        return !(await this.elem.isEnabled());
+        return !this.isEnabled();
     }
 
     public byId(id: string): ElementFinder {
@@ -67,7 +67,7 @@ export class Widget {
     }
 
     public async waitToBePresent(timeout: number = 500): Promise<void> {
-        return this.elem.waitToBePresent(timeout);
+        return this.elem.waitUntil(async () => await this.isPresent(), timeout);
     }
 
     public async waitToBeNotPresent(timeout: number = 500): Promise<void> {
@@ -75,7 +75,7 @@ export class Widget {
     }
 
     public async waitToBeDisplayed(timeout: number = 500): Promise<void> {
-        return this.elem.waitToBeDisplayed(timeout);
+        return this.elem.waitUntil(async () => await this.isDisplayed(), timeout);
     }
 
     public async waitToBeNotDisplayed(timeout: number = 500): Promise<void> {
@@ -83,7 +83,7 @@ export class Widget {
     }
 
     public async waitToBeClickable(timeout: number = 500): Promise<void> {
-        return this.elem.waitToBeClickable(timeout);
+        return this.elem.waitUntil(async () => await this.isClickable(), timeout);
     }
 
     public async waitToBeNotClickable(timeout: number = 500): Promise<void> {
@@ -91,11 +91,11 @@ export class Widget {
     }
 
     public async waitToBeEnabled(timeout: number = 500): Promise<void> {
-        return this.elem.waitToBeEnabled(timeout);
+        return this.elem.waitUntil(async () => await this.isEnabled(), timeout);
     }
 
     public async waitToBeDisabled(timeout: number = 500): Promise<void> {
-        return this.elem.waitUntil(async () => !(await this.isEnabled()), timeout);
+        return this.elem.waitUntil(async () => await this.isDisabled(), timeout);
     }
 
     public async waitUntil(condition: () => boolean | Promise<boolean>, timeout: number = 5000): Promise<void> {

--- a/src/widgets/widget.ts
+++ b/src/widgets/widget.ts
@@ -18,6 +18,10 @@ export class Widget {
         return this.elem.isDisplayed();
     }
 
+    public async isClickable(): Promise<boolean> {
+        return this.elem.isClickable();
+    }
+
     public async isEnabled(): Promise<boolean> {
         return this.elem.isEnabled();
     }
@@ -68,6 +72,30 @@ export class Widget {
 
     public async waitToBeNotPresent(timeout: number = 500): Promise<void> {
         return this.elem.waitUntil(async () => !(await this.isPresent()), timeout);
+    }
+
+    public async waitToBeDisplayed(timeout: number = 500): Promise<void> {
+        return this.elem.waitToBeDisplayed(timeout);
+    }
+
+    public async waitToBeNotDisplayed(timeout: number = 500): Promise<void> {
+        return this.elem.waitUntil(async () => !(await this.isDisplayed()), timeout);
+    }
+
+    public async waitToBeClickable(timeout: number = 500): Promise<void> {
+        return this.elem.waitToBeClickable(timeout);
+    }
+
+    public async waitToBeNotClickable(timeout: number = 500): Promise<void> {
+        return this.elem.waitUntil(async () => !(await this.isClickable()), timeout);
+    }
+
+    public async waitToBeEnabled(timeout: number = 500): Promise<void> {
+        return this.elem.waitToBeEnabled(timeout);
+    }
+
+    public async waitToBeDisabled(timeout: number = 500): Promise<void> {
+        return this.elem.waitUntil(async () => !(await this.isEnabled()), timeout);
     }
 
     public async waitUntil(condition: () => boolean | Promise<boolean>, timeout: number = 5000): Promise<void> {


### PR DESCRIPTION
# PR Details

Fixed bug in method to wait for the loading overlay of a grid to disappear. There was a missing await, so the wait wasn't applied properly.

## Description

Resolved bug by added the missing await. Also, took advantage of this change to:
- Rename method to `waitToBeLoaded()`
- Handled arguments as an object, so we are allowed to configure each one independently

## Related Issue

[#19](https://github.com/systelab/systelab-components-wdio-test/issues/19) New waitUntilLoaded() method of grids doesn't wait properly for loading overlay to disappear

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] I have added tests to cover my changes (at least 1 spec for each widget with the same coverage as the master branch)
- [ ] All tests (new and existing) passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
