### PR TITLE
Auto-open options list in combobox widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/widgets/combobox.ts
+++ b/src/widgets/combobox.ts
@@ -3,12 +3,34 @@ import { ElementArrayFinder } from "../wdio";
 
 
 export class ComboBox extends Widget {
-
     public async click(): Promise<void> {
-        return this.elem.click();
+        return this.elem.byCSS('dropdown-toggle').click();
+    }
+
+    public async isOptionsListOpen(): Promise<boolean> {
+        const nOptions = await this.allByCSS('.ag-cell-value').count();
+        return nOptions > 0;
+    }
+
+    public async openOptionsList(): Promise<void> {
+        const isOpen = await this.isOptionsListOpen();
+        if (!isOpen) {
+            await this.elem.click();
+            await this.waitUntil(async () => this.isOptionsListOpen());
+        }
+    }
+
+    public async closeOptionsList(): Promise<void> {
+        const isOpen = await this.isOptionsListOpen();
+        if (isOpen) {
+            await this.elem.click();
+            await this.waitUntil(async () => !(await this.isOptionsListOpen()));
+        }
     }
 
     public async getOptions(): Promise<string[]> {
+        await this.openOptionsList();
+
         let content: string[] = [];
         let rows: ElementArrayFinder = this.allByCSS('.ag-cell-value');
         let numberOfItems: number = await rows.count();
@@ -16,16 +38,20 @@ export class ComboBox extends Widget {
             let text: string = await rows.get(i).getText();
             content.push(text);
         }
-        return content;
-    }
 
-    public async selectOptionByNumber(i: number): Promise<void> {
-        return this.allByCSS(`[role='row'][row-index='` + i + `']`).get(1).click();
+        await this.closeOptionsList();
+
+        return content;
     }
 
     public async selectOptionByText(text: string): Promise<void> {
         const options = await this.getOptions();
         const optionIndex = options.findIndex((option) => option === text);
         return this.selectOptionByNumber(optionIndex);
+    }
+
+    public async selectOptionByNumber(i: number): Promise<void> {
+        await this.openOptionsList();
+        await this.allByCSS(`[role='row'][row-index='` + i + `']`).get(1).click();
     }
 }


### PR DESCRIPTION
# PR Details

Updated combobox widget object to make it more smart, so opening-closing the list of options is done automatically by the widget.

## Description

* Added new methods in combobox to open and close the list of options. They are smart enough to do nothing if the list of options is already added.
* Added conditional waits just after opening/closing the list of options, so the tests won't continue until the operation is ready
* Updated existing methods to automatically open the list of options (if it wasn't yet), so tests won't have to explicitly open the list to operate with the combobox

## Related Issue

[#21 Auto-open options list in combobox widget](https://github.com/systelab/systelab-components-wdio-test/issues/21) 


## Motivation and Context

Simplify the usage in tests, so they don't need to worry about opening/closing the list of options, That would make tests more readable and also more robust, as some waits are internally done by the widget.

## How Has This Been Tested

By using a local package of the library and using it in one of the projects of the company.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] I have added tests to cover my changes (at least 1 spec for each widget with the same coverage as the master branch)
- [ ] All tests (new and existing) passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
