### PR TITLE
Add getProperty method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/wdio/element-finder.ts
+++ b/src/wdio/element-finder.ts
@@ -91,7 +91,7 @@ export class ElementFinder {
         return (await (await this.findElement()).getCSSProperty(name)).value as string;
     }
 
-    public async getProperty(name: string): Promise<object|string|number|boolean> {
+    public async getProperty(name: string): Promise<any> {
         return (await this.findElement()).getProperty(name);
     }
 

--- a/src/wdio/element-finder.ts
+++ b/src/wdio/element-finder.ts
@@ -91,6 +91,10 @@ export class ElementFinder {
         return (await (await this.findElement()).getCSSProperty(name)).value as string;
     }
 
+    public async getProperty(name: string): Promise<object|string|number|boolean> {
+        return (await this.findElement()).getProperty(name);
+    }
+
 
     // Actions
     public async click(): Promise<void> {


### PR DESCRIPTION
# PR Details

Add a new method into ElementFinder class to expose the getProperty() method of WDIO API.

## Description

For radio button inputs or other form controls, it is necessary to query the status of the "checked" property to know if it is selected or not. Thus, the getProperty method has been added into the ElementFinder class.

## Related Issue

#32 

## How Has This Been Tested

This has been tested using this method in radio button component for CSW project

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] I have added tests to cover my changes (at least 1 spec for each widget with the same coverage as the master branch)
- [ ] All tests (new and existing) passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
