### PR TITLE
added browser capabilities for the browser version and os-platform-na…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/utils/test-identification.util.ts
+++ b/src/utils/test-identification.util.ts
@@ -1,5 +1,5 @@
 import { ReportUtility } from "./report.util";
-
+import { Browser } from "../wdio";
 
 export class TestIdentification
 {
@@ -19,10 +19,10 @@ export class TestIdentification
     }
 
     public static captureEnvironment(): void {
-        ReportUtility.addLabel("OS", (browser.capabilities as any).platformName);
+        ReportUtility.addLabel("OS", Browser.getOperatingSystem());
         ReportUtility.addLabel("testExecutionDateTime", new Date().toLocaleString());
-        ReportUtility.addLabel("browser", (browser.capabilities as any).browserName);
-        ReportUtility.addLabel("browserVersion", (browser.capabilities as any).browserVersion);
+        ReportUtility.addLabel("browser", Browser.getName());
+        ReportUtility.addLabel("browserVersion", Browser.getVersion());
         ReportUtility.addLabel("appVersion", this.appVersion);
     }
 }

--- a/src/utils/test-identification.util.ts
+++ b/src/utils/test-identification.util.ts
@@ -19,10 +19,10 @@ export class TestIdentification
     }
 
     public static captureEnvironment(): void {
-        ReportUtility.addLabel("OS", "TODO");
+        ReportUtility.addLabel("OS", (browser.capabilities as any).platformName);
         ReportUtility.addLabel("testExecutionDateTime", new Date().toLocaleString());
         ReportUtility.addLabel("browser", (browser.capabilities as any).browserName);
-        ReportUtility.addLabel("browserVersion", "TODO");
+        ReportUtility.addLabel("browserVersion", (browser.capabilities as any).browserVersion);
         ReportUtility.addLabel("appVersion", this.appVersion);
     }
 }

--- a/src/wdio/browser.ts
+++ b/src/wdio/browser.ts
@@ -101,4 +101,20 @@ export class Browser {
     public static async saveScreenshot(filepath: string): Promise<void> {
         await browser.saveScreenshot(filepath);
     }
+
+    // Capabilities and Status
+    public static getName(): string {
+        const caps = browser.capabilities as any;
+        return caps.browserName;
+    }
+
+    public static getVersion(): string {
+        const caps = browser.capabilities as any;
+        return caps.browserVersion;
+    }
+
+    public static getOperatingSystem(): string {
+        const caps = browser.capabilities as any;
+        return caps.platformName;
+    }
 }


### PR DESCRIPTION


# PR Details

Pick browser capabilities pending to be retrieved and reported when executing the test

## Description

Fields like browserVersion or OperatingSystem are pending to be informed and reported in the execution reports.

## Related Issue

#3 

## Motivation and Context

This information is relevant when reporting the execution of the tests, browserVersion mainly, but the operating system (platform name) could be also relevant.

## How Has This Been Tested

This modifications have been tested outside the library along with prevous versions to ascertain the info retrieved is the current version of the browser, the name of the operating system does not include the version.

## Types of changes


- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] I have added tests to cover my changes (at least 1 spec for each widget with the same coverage as the master branch)
- [ ] All tests (new and existing) passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
