### PR TITLE
Feature 42

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ it(`Should be able to do something`, async () => {
 	});
 ```
 
-### Allure
+### Allure Reporting
 
 In order to document test cases we suggest to use Allure.
 
@@ -119,6 +119,9 @@ await ReportUtility.addExpectedResult("Invalid username or password message is d
 	AssertionUtility.expectEqual(await loginPage.getMessagePopup().getTextMessage(), "Invalid username or password");
 });
 ```
+#### Traceability
+
+See [traceability](TRACEABILITY.md) page for details on how to add into Allure Reporting traceability of specs against test cases.
 
 ### Screenshots
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ await ReportUtility.addExpectedResult("Invalid username or password message is d
 ```
 #### Traceability
 
-See [traceability](TRACEABILITY.md) page for details on how to add into Allure Reporting traceability of specs against test cases.
+See [traceability](TRACEABILITY.md) page for details on how to add into Allure Reporting traceability of specs with test cases.
 
 ### Screenshots
 

--- a/TRACEABILITY.md
+++ b/TRACEABILITY.md
@@ -1,6 +1,6 @@
 # Traceability utility
 
-This utility provides several methods to facilitate traceability of specs against test cases. 
+This utility provides several methods to facilitate traceability of specs with test cases. 
 
 ## Trace of specifications
 
@@ -29,7 +29,7 @@ describe('WDIO-TC-AT-SPECIFIC_TEST', () => {
 ```
 ### Tracing specs at "describe" (suite) level
 
-With this approach, specs are directly set only at suite level, and they should be specified there with the `registerCovered()` method:
+With this approach, specs are directly set only at suite level, and they should be specified there with the `registerCoveredSpecs()` method:
 
 ```typescript
 describe('WDIO-TC-AT-SPECIFIC_TEST', () => {

--- a/TRACEABILITY.md
+++ b/TRACEABILITY.md
@@ -1,0 +1,43 @@
+# Traceability utility
+
+This utility provides several methods to facilitate traceability of specs against test cases. 
+
+## Trace of specifications
+
+This utility has two working modes:
+ - Add specs at either "it" (test) level
+ - Add specs at "describe" (suite) level
+
+### Tracing specs at "it" (test) level 
+Setting specs at "it" level, the specs related to each "it" test are added with the `addCoveredSpecs()` method:
+```typescript
+TraceabilityUtility.addCoveredSpecs(['SwS6015', 'SwS6016']);
+it('Perform a Log in', async () => {
+    await LoginActionService.login(true, UserCredentialsList.getDefault());
+    ...
+});
+```    
+Then at suite level all specs added at "it" level can be dumped to the allure report at once with the `dumpCoveredSpecs()` method:
+```typescript
+describe('WDIO-TC-AT-SPECIFIC_TEST', () => {
+    beforeEach(async () => {
+        TestIdentification.setTmsLink('WDIO-TC-AT-SPECIFIC_TEST');
+        ...
+        TraceabilityUtility.dumpCoveredSpecs();
+    });
+});
+```
+### Tracing specs at "describe" (suite) level
+
+With this approach, specs are directly set only at suite level, and they should be specified there with the `registerCovered()` method:
+
+```typescript
+describe('WDIO-TC-AT-SPECIFIC_TEST', () => {
+    beforeEach(async () => {
+        TestIdentification.setTmsLink('WDIO-TC-AT-SPECIFIC_TEST');
+        ...
+        TraceabilityUtility.registerCoveredSpecs(['SwSxxx1', 'SwSxxx2', 'SwSxxx3', 'SwSxxx4']);
+    });
+});
+```
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/reporters/test-case.reporter.js
+++ b/src/reporters/test-case.reporter.js
@@ -1,5 +1,6 @@
 const WDIOReporter = require("@wdio/reporter").default
 const colors = require("colors");
+const {TraceabilityUtility} = require("../../lib/utils/traceability.util");
 
 
 const jasmineTestCaseReporter =
@@ -38,6 +39,12 @@ class TestCaseReporter extends WDIOReporter
     {
         this.indents++;
         console.log(colors.blue(`${this.indent()}${suiteStats.fullTitle}`));
+
+        if (TraceabilityUtility.hasCoveredSpecs()) {
+            this.indents++;
+            console.log(colors.gray(`${this.indent()}Covered Specs: ${TraceabilityUtility.getCoveredSpecsPrettyString()}`));
+            this.indents--;
+        }
     }
 
     onTestStart(testStats)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export * from './assertion.util';
 export * from './report.util';
-export * from './test-identification.util';
 export * from './screenshot.util';
+export * from './test-identification.util';
 export * from './traceability.util';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './assertion.util';
 export * from './report.util';
 export * from './test-identification.util';
 export * from './screenshot.util';
+export * from './traceability.util';

--- a/src/utils/traceability.util.ts
+++ b/src/utils/traceability.util.ts
@@ -1,0 +1,31 @@
+import {ReportUtility} from "./report.util";
+
+export class TraceabilityUtility {
+    private static coveredSpecs: Set<string> = new Set<string>();
+
+    public static registerCoveredSpecs(specList: string[]): void {
+        this.addCoveredSpecs(specList);
+        this.dumpCoveredSpecs();
+        this.clearCoveredSpecs();
+    }
+
+    public static addCoveredSpecs(specsList: string[]): void {
+        specsList.forEach(spec => this.coveredSpecs.add(spec));
+    }
+
+    public static clearCoveredSpecs(): void {
+        this.coveredSpecs.clear();
+    }
+
+    public static dumpCoveredSpecs(): void {
+        ReportUtility.addLabel("coveredSpecs", this.getCoveredSpecsPrettyString());
+    }
+
+    public static getCoveredSpecsPrettyString(): string {
+        return [...this.coveredSpecs].sort().join(', ');
+    }
+
+    public static hasCoveredSpecs(): boolean {
+        return this.coveredSpecs.size > 0;
+    }
+}


### PR DESCRIPTION
# PR Details

Traceability Utility implementation to facilitate traceability of specs against test cases. 

## Description

Traceability Utility implementation to facilitate traceability of specs against test cases. This utility allows traceability of specs either at "it" (test) level or at "describe" (suite) level.

## Related Issue

#42 

## Motivation and Context

From now on, this utility can be used to dump/record specs to Allure Reporting.

## How Has This Been Tested

No specific testing of this has been carried out within the library however a proof of concept has been done in the Beacon project to ensure the Traceability Utility works as expected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each widget)
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
