### PR TITLE
Update spinner.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/widgets/spinner.ts
+++ b/src/widgets/spinner.ts
@@ -11,7 +11,7 @@ export class Spinner extends Widget {
     }
 
     public async getText(): Promise<string> {
-        return this.byTagName('input').getAttribute('value');
+        return this.byTagName('input').getValue();
     }
 
     public async increase(): Promise<void> {

--- a/src/widgets/spinner.ts
+++ b/src/widgets/spinner.ts
@@ -13,6 +13,16 @@ export class Spinner extends Widget {
     public async getText(): Promise<string> {
         return this.byTagName('input').getValue();
     }
+    
+    public async getValue(): Promise<number> {
+        return +(await this.getText());
+    }
+
+    public async setValue(value: number): Promise<void> {
+        await this.clear();
+        await this.setText(value.toString());
+        await Browser.pressTab();
+    }
 
     public async increase(): Promise<void> {
         return this.byClassName('input-group-append').click();

--- a/src/widgets/spinner.ts
+++ b/src/widgets/spinner.ts
@@ -1,4 +1,5 @@
 import { Widget } from "./widget";
+import { Browser } from '../wdio';
 
 export class Spinner extends Widget {
 


### PR DESCRIPTION
getText function modified, accessing directly with getValue

# PR Details

changed getText function, using now getValue instead of getAttribute('value')

## Description

just changed the function to access the value of the builtin input component, as it's not listed as an attribute

## Related Issue

Issue #48 

## Motivation and Context

the affected function doesn't returned the value correctly

## How Has This Been Tested

used with previous version

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ x ] I have read the **CONTRIBUTING** document
- [ x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] I have added tests to cover my changes (at least 1 spec for each widget with the same coverage as the master branch)
- [ ] All tests (new and existing) passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
- [ x ] This PR has not yet defined the version, to be discussed in the review/approval of the PR.