### PR TITLE
Updated comboboxes to work also with webkitgtk + added getHTML wdio method to lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/wdio/element-finder.ts
+++ b/src/wdio/element-finder.ts
@@ -100,6 +100,10 @@ export class ElementFinder {
         return (await this.findElement()).getValue();
     }
 
+    public async getHTML(includeSelectorTag: boolean): Promise<string> {
+        return (await this.findElement()).getHTML(includeSelectorTag);
+    }
+
     public async getAttribute(name: string): Promise<string> {
         return (await this.findElement()).getAttribute(name);
     }

--- a/src/widgets/combobox.ts
+++ b/src/widgets/combobox.ts
@@ -4,7 +4,7 @@ import { ElementArrayFinder, ElementFinder } from "../wdio";
 
 export class ComboBox extends Widget {
     public async click(): Promise<void> {
-        return this.elem.byCSS('dropdown-toggle').click();
+        return this.elem.byCSS('.dropdown-toggle').click();
     }
 
     public async isOptionsListOpen(): Promise<boolean> {
@@ -14,7 +14,7 @@ export class ComboBox extends Widget {
     public async openOptionsList(): Promise<void> {
         const isOpen = await this.isOptionsListOpen();
         if (!isOpen) {
-            await this.elem.click();
+            await this.click();
             await this.waitUntil(async () => this.isOptionsListOpen());
         }
     }
@@ -22,7 +22,7 @@ export class ComboBox extends Widget {
     public async closeOptionsList(): Promise<void> {
         const isOpen = await this.isOptionsListOpen();
         if (isOpen) {
-            await this.elem.click();
+            await this.click();
             await this.waitUntil(async () => !(await this.isOptionsListOpen()));
         }
     }
@@ -49,7 +49,7 @@ export class ComboBox extends Widget {
         let rows: ElementArrayFinder = this.allByCSS('.ag-cell-value');
         let numberOfItems: number = await rows.count();
         for (let i = 0; i < numberOfItems; i++) {
-            let optionText: string = await rows.get(i).getText();
+            let optionText: string = await rows.get(i).getHTML(false);
             if (text === optionText) {
                 await this.getOptionSelector(i).click();
                 return;


### PR DESCRIPTION
# PR Details

Updated comboboxes to work also with webkitgtk + added getHTML wdio method to lib

## Description

Make comboboxes to work with webkitgtk while still work on chrome + added getHTML wdio method to lib

## Related Issue
 #64 

## Motivation and Context

Comboboxes to work with webkitgtk browser

## How Has This Been Tested

Within the beacon project, tested in both browsers: chrome & webkitgtk

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
