### PR TITLE
Allow querying position, size and bounding rectangle of a DOM element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/wdio/element-finder.ts
+++ b/src/wdio/element-finder.ts
@@ -116,6 +116,20 @@ export class ElementFinder {
         return (await this.findElement()).getProperty(name);
     }
 
+    public async getBoundingRect(): Promise<{ x: number, y: number, width: number, height: number }> {
+        const position = await this.getPosition();
+        const size = await this.getSize();
+        return { ...position, ...size };
+    }
+
+    public async getPosition(): Promise<{ x: number, y: number }> {
+        return (await this.findElement()).getLocation();
+    }
+
+    public async getSize(): Promise<{ width: number, height: number }> {
+        return (await this.findElement()).getSize();
+    }
+
 
     // Actions
     public async click(): Promise<void> {


### PR DESCRIPTION
# PR Details
Allow querying position, size and bounding rectangle of a DOM element

## Description
Extended`ElementFinder` interface by adding the following public methods:
* `getBoundingRect(): Promise<{ x: number, y: number, width: number, height: number }>`
* `getPosition(): Promise<{ x: number, y: number }>`
* `getSize(): Promise<{ width: number, height: number }>`

## Related Issue
#68

## Motivation and Context
Enables creating tests that assert on geometric properties of DOM elements (i.e sizing, positioning, ...) 

## How Has This Been Tested
Integrated in automated test suite of [systelab-virtual-keyboard](https://github.com/systelab/systelab-virtual-keyboard) repository.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
