### PR TITLE
Allow tapping (touch action) on an element 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/wdio/element-finder.ts
+++ b/src/wdio/element-finder.ts
@@ -130,6 +130,24 @@ export class ElementFinder {
         return (await this.findElement()).getSize();
     }
 
+
+    // Actions
+    public async click(): Promise<void> {
+        return (await this.findElement()).click();
+    }
+
+    public async moveTo(): Promise<void> {
+        return (await this.findElement()).moveTo();
+    }
+
+    public async clear(): Promise<void> {
+        return (await this.findElement()).clearValue();
+    }
+
+    public async write(text: string): Promise<void> {
+        return (await this.findElement()).setValue(text);
+    }
+
     public async tap(): Promise<void> {
         const element = await this.findElement() as any;
         await browser.execute((element) => {
@@ -162,24 +180,6 @@ export class ElementFinder {
             });
             element.dispatchEvent(touchEndEvent);
         }, element);
-    }
-
-
-    // Actions
-    public async click(): Promise<void> {
-        return (await this.findElement()).click();
-    }
-
-    public async moveTo(): Promise<void> {
-        return (await this.findElement()).moveTo();
-    }
-
-    public async clear(): Promise<void> {
-        return (await this.findElement()).clearValue();
-    }
-
-    public async write(text: string): Promise<void> {
-        return (await this.findElement()).setValue(text);
     }
 
 

--- a/src/wdio/element-finder.ts
+++ b/src/wdio/element-finder.ts
@@ -130,6 +130,40 @@ export class ElementFinder {
         return (await this.findElement()).getSize();
     }
 
+    public async tap(): Promise<void> {
+        const element = await this.findElement() as any;
+        await browser.execute((element) => {
+            const touchPoint = new Touch({
+                identifier: Date.now(),
+                target: element,
+                clientX: 0,
+                clientY: 0,
+                pageX: 0,
+                pageY: 0,
+                screenX: 0,
+                screenY: 0
+            });
+
+            const touchStartEvent = new TouchEvent('touchstart', {
+                cancelable: true,
+                bubbles: true,
+                touches: [touchPoint],
+                targetTouches: [],
+                changedTouches: [touchPoint]
+            });
+            element.dispatchEvent(touchStartEvent);
+
+            const touchEndEvent = new TouchEvent('touchend', {
+                cancelable: true,
+                bubbles: true,
+                touches: [touchPoint],
+                targetTouches: [],
+                changedTouches: [touchPoint]
+            });
+            element.dispatchEvent(touchEndEvent);
+        }, element);
+    }
+
 
     // Actions
     public async click(): Promise<void> {


### PR DESCRIPTION
# PR Details

Allow tapping (touch action) on an element 

## Description

Added `tap()` method on ElementFinder class to simulate a tap touch action over an element.

## Related Issue

[https://github.com/systelab/systelab-components-wdio-test/issues/70](https://github.com/systelab/systelab-components-wdio-test/issues/70)

## Motivation and Context

This is needed to emulate touch actions, which may have different behavior when being done with a touch screen and with a mouse pointer.

## How Has This Been Tested

Tested by using a local package manually deployed on systelab-virtual-keyboard project, which has WDIO test suite. The correct behavior has been checked by seeing the differences between click() and tap()

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
