### PR TITLE
Add support for WDIO standalone mode and for implementations that need to rely on browser type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/utils/automation-environment.util.ts
+++ b/src/utils/automation-environment.util.ts
@@ -15,7 +15,7 @@ export enum BrowserType {
 
 export class AutomationEnvironment {
     private static mode: AutomationMode = AutomationMode.Runner;
-    private static browser: any = null;
+    private static browser: WebdriverIO.Browser = null as unknown as WebdriverIO.Browser;
     private static browserType: BrowserType = BrowserType.Chrome;
 
     public static getMode(): AutomationMode {
@@ -28,10 +28,10 @@ export class AutomationEnvironment {
 
     public static setTestRunnerMode(): void {
         this.mode = AutomationMode.Runner;
-        this.browser = null; // Browser instance will be managed by test runner
+        this.browser = null as unknown as WebdriverIO.Browser; // Browser instance will be managed by test runner
     }
 
-    public static setStandaloneMode(browser: any): void {
+    public static setStandaloneMode(browser: WebdriverIO.Browser): void {
         this.mode = AutomationMode.Standalone;
         this.browser = browser;
     }

--- a/src/utils/automation-environment.util.ts
+++ b/src/utils/automation-environment.util.ts
@@ -15,18 +15,25 @@ export enum BrowserType {
 
 export class AutomationEnvironment {
     private static mode: AutomationMode = AutomationMode.Runner;
+    private static browser: any = null;
     private static browserType: BrowserType = BrowserType.Chrome;
 
     public static getMode(): AutomationMode {
         return this.mode;
     }
 
-    public static setTestRunnerMode(): void {
-        this.mode = AutomationMode.Runner;
+    public static getBrowser(): any {
+        return this.browser;
     }
 
-    public static setStandaloneMode(): void {
+    public static setTestRunnerMode(): void {
+        this.mode = AutomationMode.Runner;
+        this.browser = null; // Browser instance will be managed by test runner
+    }
+
+    public static setStandaloneMode(browser: any): void {
         this.mode = AutomationMode.Standalone;
+        this.browser = browser;
     }
 
     public static getBrowserType(): BrowserType {

--- a/src/utils/automation-environment.util.ts
+++ b/src/utils/automation-environment.util.ts
@@ -1,0 +1,39 @@
+
+export enum AutomationMode {
+    Runner,
+    Standalone
+}
+
+export enum BrowserType {
+    Chrome,
+    Edge,
+    Firefox,
+    Safari,
+    WebKitGTK,
+    TauriApp
+}
+
+export class AutomationEnvironment {
+    private static mode: AutomationMode = AutomationMode.Runner;
+    private static browserType: BrowserType = BrowserType.Chrome;
+
+    public static getMode(): AutomationMode {
+        return this.mode;
+    }
+
+    public static setTestRunnerMode(): void {
+        this.mode = AutomationMode.Runner;
+    }
+
+    public static setStandaloneMode(): void {
+        this.mode = AutomationMode.Standalone;
+    }
+
+    public static getBrowserType(): BrowserType {
+        return this.browserType;
+    }
+
+    public static setBrowserType(browserType: BrowserType): void {
+        this.browserType = browserType;
+    }
+}

--- a/src/wdio/automation-environment.util.ts
+++ b/src/wdio/automation-environment.util.ts
@@ -15,25 +15,30 @@ export enum BrowserType {
 
 export class AutomationEnvironment {
     private static mode: AutomationMode = AutomationMode.Runner;
-    private static browser: WebdriverIO.Browser = null as unknown as WebdriverIO.Browser;
+    private static workingBrowser: WebdriverIO.Browser | null = null;
     private static browserType: BrowserType = BrowserType.Chrome;
 
     public static getMode(): AutomationMode {
         return this.mode;
     }
 
-    public static getBrowser(): any {
-        return this.browser;
+    public static getWorkingBrowser(): WebdriverIO.Browser {
+        if (this.workingBrowser) {
+            return this.workingBrowser;
+        }
+        else {
+            return browser;
+        }
     }
 
     public static setTestRunnerMode(): void {
         this.mode = AutomationMode.Runner;
-        this.browser = null as unknown as WebdriverIO.Browser; // Browser instance will be managed by test runner
+        this.workingBrowser = null; // Browser instance will be managed by test runner
     }
 
-    public static setStandaloneMode(browser: WebdriverIO.Browser): void {
+    public static setStandaloneMode(workingBrowser: WebdriverIO.Browser): void {
         this.mode = AutomationMode.Standalone;
-        this.browser = browser;
+        this.workingBrowser = workingBrowser;
     }
 
     public static getBrowserType(): BrowserType {

--- a/src/wdio/browser.ts
+++ b/src/wdio/browser.ts
@@ -5,39 +5,40 @@ import { LocatorType } from "./locator";
 import { ElementArrayFinder, ElementFinder } from "./element-finder";
 import { DefaultTimeout } from "./default-timeout";
 import { Constants } from "../constants";
+import { AutomationEnvironment } from "../utils/automation-environment.util";
 
 
 export class Browser {
 
     // Navigation
     public static async navigateToURL(url: string): Promise<void> {
-        await browser.url(url);
+        await this.getWorkingBrowser().url(url);
     }
 
 
     // Keyboard
     public static async pressEsc(): Promise<void> {
-        return browser.keys(['Escape']);
+        return this.getWorkingBrowser().keys(['Escape']);
     }
 
     public static async pressTab(): Promise<void> {
-        return browser.keys(['Tab']);
+        return this.getWorkingBrowser().keys(['Tab']);
     }
 
     public static async pressBackspace(): Promise<void> {
-        return browser.keys(['Backspace']);
+        return this.getWorkingBrowser().keys(['Backspace']);
     }
 
     public static async pressEnter(): Promise<void> {
-        return browser.keys(['Enter']);
+        return this.getWorkingBrowser().keys(['Enter']);
     }
 
     public static async pressDelete(): Promise<void> {
-        return browser.keys(['Delete']);
+        return this.getWorkingBrowser().keys(['Delete']);
     }
     
     public static async writeText(stringToWrite: string): Promise<void> {
-        await browser.keys(stringToWrite.split(''));
+        await this.getWorkingBrowser().keys(stringToWrite.split(''));
     }
     
 
@@ -92,52 +93,59 @@ export class Browser {
 
     // Flow control
     public static async sleep(duration: number): Promise<void> {
-        await browser.pause(duration);
+        await this.getWorkingBrowser().pause(duration);
     }
 
     public static async waitUntil(condition: () => boolean | Promise<boolean>, timeout: number = DefaultTimeout.SLOW_WAIT): Promise<void> {
-        await browser.waitUntil(condition, {timeout});
+        await this.getWorkingBrowser().waitUntil(condition, {timeout});
     }
 
 
     // Screenshots
     public static async takeScreenshot(): Promise<string> {
         const tempFilepath = tmp.tmpNameSync({postfix: '.png'});
-        const screenshotBuffer: Buffer = await browser.saveScreenshot(tempFilepath);
+        const screenshotBuffer: Buffer = await this.getWorkingBrowser().saveScreenshot(tempFilepath);
         fs.unlinkSync(tempFilepath);
         return screenshotBuffer.toString('base64');
     }
 
     public static async saveScreenshot(filepath: string): Promise<void> {
-        await browser.saveScreenshot(filepath);
+        await this.getWorkingBrowser().saveScreenshot(filepath);
     }
 
     // Capabilities and Status
     public static getName(): string {
-        const caps = browser.capabilities as any;
+        const caps = this.getWorkingBrowser().capabilities as any;
         return caps.browserName;
     }
 
     public static getVersion(): string {
-        const caps = browser.capabilities as any;
+        const caps = this.getWorkingBrowser().capabilities as any;
         return caps.browserVersion;
     }
 
     public static getOperatingSystem(): string {
-        const caps = browser.capabilities as any;
+        const caps = this.getWorkingBrowser().capabilities as any;
         return caps.platformName;
     }
 
     // Window
     public static async getWindowSize(): Promise<{ width: number, height: number }> {
-        return await browser.getWindowSize() as { width: number; height: number };
+        return await this.getWorkingBrowser().getWindowSize() as { width: number; height: number };
     }
 
     public static async setWindowSize(width: number, height: number): Promise<void> {
-        await browser.setWindowSize(width, height);
+        await this.getWorkingBrowser().setWindowSize(width, height);
     }
 
     public static async setFullscreen(): Promise<void> {
-        await browser.fullscreenWindow();
+        await this.getWorkingBrowser().fullscreenWindow();
+    }
+
+
+    // Auxiliary methods
+    private static getWorkingBrowser(): WebdriverIO.Browser {
+        const workingBrowser = AutomationEnvironment.getBrowser();
+        return (workingBrowser !== null) ? workingBrowser : browser;
     }
 }

--- a/src/wdio/browser.ts
+++ b/src/wdio/browser.ts
@@ -1,44 +1,44 @@
 import * as tmp from "tmp";
 import * as fs from "fs";
 
+import { AutomationEnvironment } from "./automation-environment.util";
 import { LocatorType } from "./locator";
 import { ElementArrayFinder, ElementFinder } from "./element-finder";
 import { DefaultTimeout } from "./default-timeout";
 import { Constants } from "../constants";
-import { AutomationEnvironment } from "../utils/automation-environment.util";
 
 
 export class Browser {
 
     // Navigation
     public static async navigateToURL(url: string): Promise<void> {
-        await this.getWorkingBrowser().url(url);
+        await AutomationEnvironment.getWorkingBrowser().url(url);
     }
 
 
     // Keyboard
     public static async pressEsc(): Promise<void> {
-        return this.getWorkingBrowser().keys(['Escape']);
+        return AutomationEnvironment.getWorkingBrowser().keys(['Escape']);
     }
 
     public static async pressTab(): Promise<void> {
-        return this.getWorkingBrowser().keys(['Tab']);
+        return AutomationEnvironment.getWorkingBrowser().keys(['Tab']);
     }
 
     public static async pressBackspace(): Promise<void> {
-        return this.getWorkingBrowser().keys(['Backspace']);
+        return AutomationEnvironment.getWorkingBrowser().keys(['Backspace']);
     }
 
     public static async pressEnter(): Promise<void> {
-        return this.getWorkingBrowser().keys(['Enter']);
+        return AutomationEnvironment.getWorkingBrowser().keys(['Enter']);
     }
 
     public static async pressDelete(): Promise<void> {
-        return this.getWorkingBrowser().keys(['Delete']);
+        return AutomationEnvironment.getWorkingBrowser().keys(['Delete']);
     }
     
     public static async writeText(stringToWrite: string): Promise<void> {
-        await this.getWorkingBrowser().keys(stringToWrite.split(''));
+        await AutomationEnvironment.getWorkingBrowser().keys(stringToWrite.split(''));
     }
     
 
@@ -93,59 +93,52 @@ export class Browser {
 
     // Flow control
     public static async sleep(duration: number): Promise<void> {
-        await this.getWorkingBrowser().pause(duration);
+        await AutomationEnvironment.getWorkingBrowser().pause(duration);
     }
 
     public static async waitUntil(condition: () => boolean | Promise<boolean>, timeout: number = DefaultTimeout.SLOW_WAIT): Promise<void> {
-        await this.getWorkingBrowser().waitUntil(condition, {timeout});
+        await AutomationEnvironment.getWorkingBrowser().waitUntil(condition, {timeout});
     }
 
 
     // Screenshots
     public static async takeScreenshot(): Promise<string> {
         const tempFilepath = tmp.tmpNameSync({postfix: '.png'});
-        const screenshotBuffer: Buffer = await this.getWorkingBrowser().saveScreenshot(tempFilepath);
+        const screenshotBuffer: Buffer = await AutomationEnvironment.getWorkingBrowser().saveScreenshot(tempFilepath);
         fs.unlinkSync(tempFilepath);
         return screenshotBuffer.toString('base64');
     }
 
     public static async saveScreenshot(filepath: string): Promise<void> {
-        await this.getWorkingBrowser().saveScreenshot(filepath);
+        await AutomationEnvironment.getWorkingBrowser().saveScreenshot(filepath);
     }
 
     // Capabilities and Status
     public static getName(): string {
-        const caps = this.getWorkingBrowser().capabilities as any;
+        const caps = AutomationEnvironment.getWorkingBrowser().capabilities as any;
         return caps.browserName;
     }
 
     public static getVersion(): string {
-        const caps = this.getWorkingBrowser().capabilities as any;
+        const caps = AutomationEnvironment.getWorkingBrowser().capabilities as any;
         return caps.browserVersion;
     }
 
     public static getOperatingSystem(): string {
-        const caps = this.getWorkingBrowser().capabilities as any;
+        const caps = AutomationEnvironment.getWorkingBrowser().capabilities as any;
         return caps.platformName;
     }
 
     // Window
     public static async getWindowSize(): Promise<{ width: number, height: number }> {
-        return await this.getWorkingBrowser().getWindowSize() as { width: number; height: number };
+        return await AutomationEnvironment.getWorkingBrowser().getWindowSize() as { width: number; height: number };
     }
 
     public static async setWindowSize(width: number, height: number): Promise<void> {
-        await this.getWorkingBrowser().setWindowSize(width, height);
+        await AutomationEnvironment.getWorkingBrowser().setWindowSize(width, height);
     }
 
     public static async setFullscreen(): Promise<void> {
-        await this.getWorkingBrowser().fullscreenWindow();
-    }
-
-
-    // Auxiliary methods
-    private static getWorkingBrowser(): WebdriverIO.Browser {
-        const workingBrowser = AutomationEnvironment.getBrowser();
-        return (workingBrowser !== null) ? workingBrowser : browser;
+        await AutomationEnvironment.getWorkingBrowser().fullscreenWindow();
     }
 }

--- a/src/wdio/element-finder.ts
+++ b/src/wdio/element-finder.ts
@@ -3,6 +3,7 @@ import { Locator, LocatorType } from "./locator";
 import * as tmp from "tmp";
 import fs from "fs";
 import { Constants } from "../constants";
+import { AutomationEnvironment } from "./automation-environment.util";
 
 
 export class ElementFinder {
@@ -150,7 +151,7 @@ export class ElementFinder {
 
     public async tap(): Promise<void> {
         const element = await this.findElement() as any;
-        await browser.execute((element) => {
+        await AutomationEnvironment.getWorkingBrowser().execute((element) => {
             const touchPoint = new Touch({
                 identifier: Date.now(),
                 target: element,
@@ -230,7 +231,7 @@ export class ElementFinder {
                 throw 'Unsupported locator type for parent item: ' + this.parent.getLocator().type;
             }
         } else {
-            return $(this.locator.selector as string);
+            return AutomationEnvironment.getWorkingBrowser().$(this.locator.selector as string);
         }
     }
 }
@@ -255,7 +256,7 @@ export class ElementArrayFinder {
         if (this.parent) {
             return (await (await this.parent.findElement()).$$(this.locator.selector as string));
         } else {
-            return $$(this.locator.selector as string);
+            return AutomationEnvironment.getWorkingBrowser().$$(this.locator.selector as string);
         }
     }
 }


### PR DESCRIPTION
# PR Details
- Allow configuring which WDIO mode to use: TestRunner or Standalone
- Allow configuring browser type and implemented some actions in a different way for Tauri applications
- Kept as default the test runner mode and Chrome browser

## Related Issue

https://github.com/systelab/systelab-components-wdio-test/issues/72

## Motivation and Context

* Standalone mode can be very useful for testing desktop applications, as they need to be started / stopped as part of the test
* Tauri applications may need workarounds to use automation based on WDIO, so certain actions may need to be implemented in a different way (i.e by using a `browser.execute(...)` method).

## How Has This Been Tested

* Integration into Beacon project, that uses both modes, test runner and standalone
* Tauri App differences are also used in this project

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
