### PR TITLE
Updated ScreenshotReporter to work also in Standalone mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [

--- a/src/reporters/screenshot.reporter.ts
+++ b/src/reporters/screenshot.reporter.ts
@@ -9,7 +9,7 @@ export class ScreenshotReporter {
         this.basePath = basePath;
     }
 
-    public static beforeSuite(suite: any = null): void {
+    public static beforeSuite(suite: any): void {
         this.specCount = 0;
     }
 

--- a/src/reporters/screenshot.reporter.ts
+++ b/src/reporters/screenshot.reporter.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import {AutomationEnvironment} from "../wdio";
 
 export class ScreenshotReporter {
     private static basePath = "./reports/screenshots";
@@ -8,12 +9,13 @@ export class ScreenshotReporter {
         this.basePath = basePath;
     }
 
-    public static beforeSuite(suite: any): void {
+    public static beforeSuite(suite: any = null): void {
         this.specCount = 0;
     }
 
-    public static async afterTest(test: { description: string, fullName: string }, context: any,
-                                     status: { error: any, result: any, duration: any, passed: any, retries: any }): Promise<void> {
+    public static async afterTest(test: { description: string, fullName: string },
+                                  context: any = null,
+                                  status: { error: any, result: any, duration: any, passed: any, retries: any } | null = null): Promise<void> {
         this.specCount++;
         const suiteName = test.fullName.slice(0, -1 * (test.description.length)).trim();
         try {
@@ -24,7 +26,12 @@ export class ScreenshotReporter {
             const screenshotFilename = `${this.specCount.toString().padStart(2, "0")}-${test.description}`;
             const screenshotFilenameClean = this.getSanitizedFilename(screenshotFilename);
             const screenshotFilepath = `${screenshotFolderPath}/${screenshotFilenameClean}.png`;
-            await browser.saveScreenshot(screenshotFilepath);
+            const workingBrowser: WebdriverIO.Browser = AutomationEnvironment.getWorkingBrowser();
+            if (workingBrowser) {
+                await workingBrowser.saveScreenshot(screenshotFilepath);
+            } else {
+                fs.writeFileSync(screenshotFilepath.replace('.png', '-[no-working-browser].png'), '');
+            }
         } catch(e) {
             console.log(e);
         }

--- a/src/reporters/standalone-test-case.reporter.ts
+++ b/src/reporters/standalone-test-case.reporter.ts
@@ -1,14 +1,11 @@
-import {ScreenshotReporter} from "./screenshot.reporter";
-
 const colors = require("colors");
-
 import { TraceabilityUtility } from "../utils";
 
-import CustomReporter = jasmine.CustomReporter
-import JasmineStartedInfo = jasmine.JasmineStartedInfo
-import JasmineDoneInfo = jasmine.JasmineDoneInfo
-import SuiteResult = jasmine.SuiteResult
-import SpecResult = jasmine.SpecResult
+import CustomReporter = jasmine.CustomReporter;
+import JasmineStartedInfo = jasmine.JasmineStartedInfo;
+import JasmineDoneInfo = jasmine.JasmineDoneInfo;
+import SuiteResult = jasmine.SuiteResult;
+import SpecResult = jasmine.SpecResult;
 
 
 export class StandaloneTestCaseReporter implements CustomReporter {
@@ -20,17 +17,12 @@ export class StandaloneTestCaseReporter implements CustomReporter {
     constructor() {
     }
 
-    public getCurrentSpec(): SpecResult | null {
-        return this.currentSpec;
-    }
-
     public jasmineStarted(suiteInfo: JasmineStartedInfo): void {
         (jasmine.getEnv() as any).testCaseReporter = this;
         console.log("");
     }
 
     public suiteStarted(suite: SuiteResult): void {
-        ScreenshotReporter.beforeSuite();
         this.indents++;
         console.log(colors.blue(`${this.indent()}${suite.description}`));
 

--- a/src/reporters/standalone-test-case.reporter.ts
+++ b/src/reporters/standalone-test-case.reporter.ts
@@ -1,3 +1,5 @@
+import {ScreenshotReporter} from "./screenshot.reporter";
+
 const colors = require("colors");
 
 import { TraceabilityUtility } from "../utils";
@@ -18,12 +20,17 @@ export class StandaloneTestCaseReporter implements CustomReporter {
     constructor() {
     }
 
+    public getCurrentSpec(): SpecResult | null {
+        return this.currentSpec;
+    }
+
     public jasmineStarted(suiteInfo: JasmineStartedInfo): void {
         (jasmine.getEnv() as any).testCaseReporter = this;
         console.log("");
     }
 
     public suiteStarted(suite: SuiteResult): void {
+        ScreenshotReporter.beforeSuite();
         this.indents++;
         console.log(colors.blue(`${this.indent()}${suite.description}`));
 

--- a/src/wdio/automation-environment.ts
+++ b/src/wdio/automation-environment.ts
@@ -23,8 +23,8 @@ export class AutomationEnvironment {
     }
 
     public static getWorkingBrowser(): WebdriverIO.Browser {
-        if (this.workingBrowser) {
-            return this.workingBrowser;
+        if (this.mode === AutomationMode.Standalone) {
+            return <WebdriverIO.Browser>this.workingBrowser;
         }
         else {
             return browser;

--- a/src/wdio/automation-environment.ts
+++ b/src/wdio/automation-environment.ts
@@ -24,7 +24,11 @@ export class AutomationEnvironment {
 
     public static getWorkingBrowser(): WebdriverIO.Browser {
         if (this.mode === AutomationMode.Standalone) {
-            return <WebdriverIO.Browser>this.workingBrowser;
+            if (this.workingBrowser) {
+                return this.workingBrowser;
+            } else {
+                throw new Error('No working browser defined in WDIO standalone mode');
+            }
         }
         else {
             return browser;


### PR DESCRIPTION
# PR Details

Updated ScreenshotReporter to work also in Standalone mode

## Description

Updated ScreenshotReporter to work also in Standalone mode, adapted StandaloneTestCaseReporter and AutomationEnvironment to achieve so.

## Related Issue
#74 

## Motivation and Context

Allow using the screenshot reporter when working with the lib in standalone mode

## How Has This Been Tested

Within the Beacon project

## Types of changes

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
