### PR TITLE
Updated write and getText to work with a Tauri app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "1.16.7",
+  "version": "1.16.8",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [


### PR DESCRIPTION
# PR Details
Improvements for write and getText methods to work with a Tauri application with WebdriverIO in standalone mode.

## Description
Improvements for write and getText methods to work with a Tauri application with WebdriverIO in standalone mode.


## Related Issue
#80 

## Motivation and Context
To use methods mentioned above to work with a Tauri application with WebdriverIO in standalone mode.

## How Has This Been Tested
Within the Beacon project

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

