### PR TITLE
WDIO 8 allure reporter fix - Addition of "links" object information

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "license": "MIT",
   "type": "module",
   "description": "Widgets to be use in the E2E Tests based in WDIO",

--- a/src/utils/report.util.ts
+++ b/src/utils/report.util.ts
@@ -13,7 +13,11 @@ export class ReportUtility {
 
     public static addLabel(label: string, value: string): void {
         allureReporter.addLabel(label, value);
-   }
+    }
+
+    public static addLink(url: string, name: string, type: string): void {
+        allureReporter.addLink(url, name, type);
+    }
 
     public static async addExpectedResult(description: string, expectationFunction: () => Promise<void>): Promise<void> {
         // @ts-ignore
@@ -23,7 +27,7 @@ export class ReportUtility {
                 testCaseReporter.onAssertStart(description);
             }
 
-            allureReporter.startStep(description);
+            allureReporter.startStep("Expectation: " + description);
             await expectationFunction();
             allureReporter.endStep(Status.PASSED);
 

--- a/src/utils/test-identification.util.ts
+++ b/src/utils/test-identification.util.ts
@@ -7,6 +7,7 @@ export class TestIdentification
 
     public static setTmsLink(tmsLink: string): void {
         ReportUtility.addLabel("tms", tmsLink);
+        ReportUtility.addLink("https://www.jamasoftware.com/", tmsLink, "tms");
     }
 
     public static setDescription(description: string): void {


### PR DESCRIPTION
# PR Details

WDIO 8 allure reporter fix - Addition of "links" object information

## Description

WDIO8 has changed a bit the allure report output files before the output files were in xml and in version 8 are in json. In order the json files work with the https://systelab.github.io/allure-reporter/ the need to have the "links" object filled in.

## Related Issue

#96 

## Motivation and Context

Allure result output json file can be uploaded into https://systelab.github.io/allure-reporter/ and the report is generated

## How Has This Been Tested

Within the Beacon project

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] I have added tests to cover my changes (at least 1 spec for each widget with the same coverage as the master branch)
- [ ] All tests (new and existing) passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
