### PR TITLE
Added support to query pseudo elements and to scrolling from lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc",
     "prepublish": "npm run build",
-    "start-remote-test-server": "npx ts-node --project tsconfig.json test/remote/server.ts",
+    "start-remote-test-server": "node --loader ts-node/esm test/remote/server.ts",
     "test-remote-server": "node -r ts-node/register -r tsconfig-paths/register node_modules/jasmine/bin/jasmine JASMINE_CONFIG_PATH=test/remote/remote-application-jasmine.json"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "license": "MIT",
   "type": "module",
   "description": "Widgets to be use in the E2E Tests based in WDIO",

--- a/src/remote/client/element-finder-remote.ts
+++ b/src/remote/client/element-finder-remote.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import {Locator, RemoteApplication} from "../../wdio/index.js";
+import {Locator, PseudoElement, RemoteApplication} from "../../wdio/index.js";
 import {HttpStatus} from "../server/http-status.js";
 
 
@@ -76,8 +76,8 @@ export class ElementFinderRemote {
     return body.attribute;
   }
 
-  public async getCSSProperty(name: string): Promise<string> {
-    const response = await this.executeEndpoint('POST', 'element/query/css-property', {locators: this.locators, name});
+  public async getCSSProperty(name: string, pseudoElement?: PseudoElement): Promise<string> {
+    const response = await this.executeEndpoint('POST', 'element/query/css-property', {locators: this.locators, name, pseudoElement});
     const body = await response.json();
     return body.property;
   }
@@ -126,6 +126,10 @@ export class ElementFinderRemote {
 
   public async tap(): Promise<void> {
     await this.executeEndpoint('POST', 'element/action/tap', {locators: this.locators});
+  }
+
+  public async scrollToElement(options: ScrollIntoViewOptions): Promise<void> {
+    await this.executeEndpoint('POST', 'element/action/scroll', {locators: this.locators, options});
   }
 
 

--- a/src/remote/server/action.api.ts
+++ b/src/remote/server/action.api.ts
@@ -1,10 +1,11 @@
-import { Request, Response } from 'express';
-import { AutomationEnvironment, ElementFinder, ElementFinderBuilder } from '../../wdio';
-import { JSONSchemaValidator } from './schema/json-schema-validator';
-import { BasicElementRequest } from './request/basic-element.request';
-import { HttpStatus } from './http-status';
-import { ErrorHandlerAPI } from './error-handler.api';
-import { WriteElementRequest } from './request/write-element.request';
+import {Request, Response} from 'express';
+import {AutomationEnvironment, ElementFinder, ElementFinderBuilder} from '../../wdio';
+import {JSONSchemaValidator} from './schema/json-schema-validator';
+import {BasicElementRequest} from './request/basic-element.request';
+import {HttpStatus} from './http-status';
+import {ErrorHandlerAPI} from './error-handler.api';
+import {WriteElementRequest} from './request/write-element.request';
+import {ScrollElementRequest} from "./request/scroll-element.request";
 
 
 export class ActionAPI {
@@ -62,6 +63,18 @@ export class ActionAPI {
             const requestBody: BasicElementRequest = JSONSchemaValidator.validateBasicElementRequest(req.body);
             const element: ElementFinder = ElementFinderBuilder.build(requestBody.locators) as ElementFinder;
             await element.tap();
+            return res.status(HttpStatus.NO_CONTENT).send();
+        } catch (err) {
+            return ErrorHandlerAPI.handle(res, err);
+        }
+    }
+
+    public static async scroll(req: Request, res: Response): Promise<any> {
+        try {
+            AutomationEnvironment.setApplication(+req.params.id);
+            const requestBody: ScrollElementRequest = JSONSchemaValidator.validateScrollRequest(req.body);
+            const element: ElementFinder = ElementFinderBuilder.build(requestBody.locators) as ElementFinder;
+            await element.scrollToElement(requestBody.options);
             return res.status(HttpStatus.NO_CONTENT).send();
         } catch (err) {
             return ErrorHandlerAPI.handle(res, err);

--- a/src/remote/server/query.api.ts
+++ b/src/remote/server/query.api.ts
@@ -6,6 +6,7 @@ import {HttpStatus} from './http-status';
 import {ErrorHandlerAPI} from './error-handler.api';
 import {HTMLRequest} from './request/html.request';
 import {PropertyElementRequest} from './request/property-element.request';
+import {CSSPropertyElementRequest} from "./request/css-property-element-request";
 
 
 export class QueryAPI {
@@ -134,9 +135,9 @@ export class QueryAPI {
   public static async getCSSProperty(req: Request, res: Response): Promise<any> {
     try {
       AutomationEnvironment.setApplication(+req.params.id);
-      const requestBody: PropertyElementRequest = JSONSchemaValidator.validatePropertyRequest(req.body);
+      const requestBody: CSSPropertyElementRequest = JSONSchemaValidator.validateCSSPropertyRequest(req.body);
       const element: ElementFinder = ElementFinderBuilder.build(requestBody.locators) as ElementFinder;
-      const property: string = await element.getCSSProperty(requestBody.name);
+      const property: string = await element.getCSSProperty(requestBody.name, requestBody.pseudoElement);
       return res.status(HttpStatus.OK).json({property}).send();
     } catch (err) {
       return ErrorHandlerAPI.handle(res, err);

--- a/src/remote/server/request/css-property-element-request.ts
+++ b/src/remote/server/request/css-property-element-request.ts
@@ -1,0 +1,7 @@
+import {BasicElementRequest} from "./basic-element.request";
+import {PseudoElement} from "../../../wdio";
+
+export interface CSSPropertyElementRequest extends BasicElementRequest{
+    name: string;
+    pseudoElement?: PseudoElement;
+}

--- a/src/remote/server/request/scroll-element.request.ts
+++ b/src/remote/server/request/scroll-element.request.ts
@@ -1,0 +1,5 @@
+import {BasicElementRequest} from "./basic-element.request";
+
+export interface ScrollElementRequest extends BasicElementRequest {
+    options?: ScrollIntoViewOptions
+}

--- a/src/remote/server/router.api.ts
+++ b/src/remote/server/router.api.ts
@@ -60,6 +60,7 @@ wdioRouter.post('/applications/:id/element/action/move-to', ActionAPI.moveTo);
 wdioRouter.post('/applications/:id/element/action/clear', ActionAPI.clear);
 wdioRouter.post('/applications/:id/element/action/write', ActionAPI.write);
 wdioRouter.post('/applications/:id/element/action/tap', ActionAPI.tap);
+wdioRouter.post('/applications/:id/element/action/scroll', ActionAPI.scroll);
 
 // Condition waits
 wdioRouter.post('/applications/:id/element/wait/present', ConditionWaitAPI.untilElementPresent);

--- a/src/remote/server/schema/css-property-element-request-schema.json
+++ b/src/remote/server/schema/css-property-element-request-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://www.werfen.com/property-element-request-schema.json",
-  "title": "Schema for a request to get element attribute/property on the application managed by WDIO REST API",
+  "$id": "http://www.werfen.com/css-property-element-request-schema.json",
+  "title": "Schema for a request to get element css attribute/property on the application managed by WDIO REST API",
   "type": "object",
   "properties": {
     "locators": {

--- a/src/remote/server/schema/css-property-element-request-schema.json
+++ b/src/remote/server/schema/css-property-element-request-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://www.werfen.com/css-property-element-request-schema.json",
-  "title": "Schema for a request to get element css attribute/property on the application managed by WDIO REST API",
+  "title": "Schema for a request to get element CSS attribute/property on the application managed by WDIO REST API",
   "type": "object",
   "properties": {
     "locators": {
@@ -32,7 +32,7 @@
     },
     "name": {
       "type": "string",
-      "description": "Property name"
+      "description": "CSS property name"
     },
     "pseudoElement": {
       "type": "string",

--- a/src/remote/server/schema/css-property-element-request-schema.json
+++ b/src/remote/server/schema/css-property-element-request-schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://www.werfen.com/property-element-request-schema.json",
+  "title": "Schema for a request to get element attribute/property on the application managed by WDIO REST API",
+  "type": "object",
+  "properties": {
+    "locators": {
+      "type": "array",
+      "description": "List of locators of element to be found",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["ElementSelector", "ArraySelector", "ArrayItem"],
+            "description": "Type of selector"
+          },
+          "selector": {
+            "type": "string",
+            "description": "Selector of element to be found. Only for ElementSelector and ArraySelector types."
+          },
+          "index": {
+            "type": "integer",
+            "description": "Index of element to be found. Only for ArrayItem type.",
+            "minimum": 0
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "name": {
+      "type": "string",
+      "description": "Property name"
+    },
+    "pseudoElement": {
+      "type": "string",
+      "enum": ["::before", "::after"],
+      "description": "Pseudo element to get the property from"
+    }
+  },
+  "required": ["locators","name"],
+  "additionalProperties": false
+}

--- a/src/remote/server/schema/json-schema-validator.ts
+++ b/src/remote/server/schema/json-schema-validator.ts
@@ -1,16 +1,18 @@
 import Ajv from 'ajv';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import {fileURLToPath} from 'url';
 
-import { BasicElementRequest } from '../request/basic-element.request';
-import { ApplicationStartRequest } from '../request/application-start.request';
-import { ApplicationNavigateRequest } from '../request/application-navigate.request';
-import { WindowSizeRequest } from '../request/window-size.request';
-import { ApplicationWriteTextRequest } from '../request/application-write-text.request';
-import { HTMLRequest } from '../request/html.request';
-import { PropertyElementRequest } from '../request/property-element.request';
-import { WriteElementRequest } from '../request/write-element.request';
+import {BasicElementRequest} from '../request/basic-element.request';
+import {ApplicationStartRequest} from '../request/application-start.request';
+import {ApplicationNavigateRequest} from '../request/application-navigate.request';
+import {WindowSizeRequest} from '../request/window-size.request';
+import {ApplicationWriteTextRequest} from '../request/application-write-text.request';
+import {HTMLRequest} from '../request/html.request';
+import {PropertyElementRequest} from '../request/property-element.request';
+import {WriteElementRequest} from '../request/write-element.request';
+import {CSSPropertyElementRequest} from "../request/css-property-element-request";
+import {ScrollElementRequest} from "../request/scroll-element.request";
 
 
 interface LoadedSchema {
@@ -53,6 +55,11 @@ export class JSONSchemaValidator {
         return data as HTMLRequest;
     }
 
+    public static validateCSSPropertyRequest(data: unknown): CSSPropertyElementRequest {
+        this.validateData(data, 'css-property-element-request-schema.json');
+        return data as CSSPropertyElementRequest;
+    }
+
     public static validatePropertyRequest(data: unknown): PropertyElementRequest {
         this.validateData(data, 'property-element-request-schema.json');
         return data as PropertyElementRequest;
@@ -61,6 +68,11 @@ export class JSONSchemaValidator {
     public static validateWriteRequest(data: unknown): WriteElementRequest {
         this.validateData(data, 'write-element-request-schema.json');
         return data as WriteElementRequest;
+    }
+
+    public static validateScrollRequest(data: unknown): ScrollElementRequest {
+        this.validateData(data, 'scroll-element-request-schema.json');
+        return data as ScrollElementRequest;
     }
 
     private static validateData(data: unknown, schemaFilename: string): void {

--- a/src/remote/server/schema/scroll-element-request-schema.json
+++ b/src/remote/server/schema/scroll-element-request-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://www.werfen.com/scroll-element-request-schema.json",
+  "title": "Schema for a request to scroll into an Element of the application managed by WDIO REST API",
+  "type": "object",
+  "properties": {
+    "locators": {
+      "type": "array",
+      "description": "List of locators of element to be found",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["ElementSelector", "ArraySelector", "ArrayItem"],
+            "description": "Type of selector"
+          },
+          "selector": {
+            "type": "string",
+            "description": "Selector of element to be found. Only for ElementSelector and ArraySelector types."
+          },
+          "index": {
+            "type": "integer",
+            "description": "Index of element to be found. Only for ArrayItem type.",
+            "minimum": 0
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "options": {
+      "type": "object",
+      "properties": {
+        "behavior": {
+          "type": "string",
+          "enum": ["auto", "smooth"]
+        },
+        "block": {
+          "type": "string",
+          "enum": ["start", "center", "end", "nearest"]
+        },
+        "inline": {
+          "type": "string",
+          "enum": ["start", "center", "end", "nearest"]
+        }
+      }
+    }
+  },
+  "required": ["locators"],
+  "additionalProperties": false
+}

--- a/src/wdio/element-finder.ts
+++ b/src/wdio/element-finder.ts
@@ -8,6 +8,7 @@ import {Constants} from "../constants.js";
 import {ElementFinderRemote} from "../remote/client/element-finder-remote.js";
 import {RemoteApplication} from "./application-manager-remote.js";
 
+export type PseudoElement = "::before" | "::after";
 
 export class ElementFinder {
   constructor(protected locator: Locator, protected parent: ElementFinder | ElementArrayFinder | null = null) {
@@ -168,11 +169,11 @@ export class ElementFinder {
     }
   }
 
-  public async getCSSProperty(name: string): Promise<string> {
+  public async getCSSProperty(name: string, pseudoElement?: PseudoElement): Promise<string> {
     if (AutomationEnvironment.isLocalMode()) {
-      return (await (await this.findElement()).getCSSProperty(name)).value as string;
+      return (await (await this.findElement()).getCSSProperty(name, pseudoElement)).value as string;
     } else {
-      return this.findRemoteElement().getCSSProperty(name);
+      return this.findRemoteElement().getCSSProperty(name, pseudoElement);
     }
   }
 
@@ -331,6 +332,15 @@ export class ElementFinder {
       }, element);
     } else {
       return this.findRemoteElement().tap();
+    }
+  }
+
+  public async scrollToElement(options: ScrollIntoViewOptions = { behavior: 'auto', block: 'center', inline: 'nearest' }): Promise<void> {
+    if (AutomationEnvironment.isLocalMode()) {
+      const element: WebdriverIO.Element = await this.findElement();
+      return element.scrollIntoView(options);
+    } else {
+      return this.findRemoteElement().scrollToElement(options);
     }
   }
 

--- a/test/postman/WDIO Remote Server.postman_collection.json
+++ b/test/postman/WDIO Remote Server.postman_collection.json
@@ -1,0 +1,280 @@
+{
+	"info": {
+		"_postman_id": "5cc4790b-05c1-4aec-be26-c902b4854ebc",
+		"name": "WDIO Remote Server",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "30743682"
+	},
+	"item": [
+		{
+			"name": "Applications Management",
+			"item": [
+				{
+					"name": "/wdio/applications/start (Chrome)",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"browserType\": \"Chrome\",\r\n    \"options\": {\r\n        \"capabilities\": {\r\n            \"browserName\": \"chrome\",\r\n            \"goog:chromeOptions\": {\r\n                \"args\": [\"--no-sandbox\", \"--disable-search-engine-choice-screen\"]\r\n            }\r\n        }\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3333/wdio/applications/start",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3333",
+							"path": [
+								"wdio",
+								"applications",
+								"start"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/wdio/applications/1/stop",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"browserType\": \"Chrome\",\r\n    \"options\": {\r\n        \"capabilities\": {\r\n            \"browserName\": \"chrome\",\r\n            \"goog:chromeOptions\": {\r\n                \"args\": [\"--no-sandbox\", \"--disable-search-engine-choice-screen\"]\r\n            }\r\n        }\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3333/wdio/applications/1/stop",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3333",
+							"path": [
+								"wdio",
+								"applications",
+								"1",
+								"stop"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/wdio/applications/1/navigate (www.werfen.com)",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"url\": \"https://www.werfen.com\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3333/wdio/applications/1/navigate",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3333",
+							"path": [
+								"wdio",
+								"applications",
+								"1",
+								"navigate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/wdio/applications/8/window/fullscreen",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"url\": \"https://www.werfen.com\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3333/wdio/applications/1/navigate",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3333",
+							"path": [
+								"wdio",
+								"applications",
+								"1",
+								"navigate"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Queries",
+			"item": [
+				{
+					"name": "/wdio/applications/1/element/query/text (Single Element Selector)",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"locators\": [\r\n        {\r\n            \"type\": \"ElementSelector\",\r\n            \"selector\": \".row-main-info .carousel-inner h1.info-container__title\"\r\n        }\r\n    ]\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3333/wdio/applications/1/element/query/text",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3333",
+							"path": [
+								"wdio",
+								"applications",
+								"1",
+								"element",
+								"query",
+								"text"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/wdio/applications/1/element/query/text (Multiple Element Selector)",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"locators\":[\r\n        {\r\n            \"type\":\"ElementSelector\",\r\n            \"selector\":\".row-main-info\"\r\n        },\r\n        {\r\n            \"type\":\"ElementSelector\",\r\n            \"selector\":\".carousel-inner\"\r\n        },\r\n        {\r\n            \"type\":\"ElementSelector\",\r\n            \"selector\":\"h1.info-container__title\"\r\n        }\r\n    ]\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3333/wdio/applications/1/element/query/text",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3333",
+							"path": [
+								"wdio",
+								"applications",
+								"1",
+								"element",
+								"query",
+								"text"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/wdio/applications/1/element/query/text (Item in Array Selector)",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"locators\": [\r\n        {\r\n            \"type\": \"ArraySelector\",\r\n            \"selector\": \"h1.info-container__title\"\r\n        },\r\n        {\r\n            \"type\": \"ArrayItem\",\r\n            \"index\": 0\r\n        }\r\n    ]\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3333/wdio/applications/1/element/query/text",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3333",
+							"path": [
+								"wdio",
+								"applications",
+								"1",
+								"element",
+								"query",
+								"text"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Actions",
+			"item": [
+				{
+					"name": "/wdio/applications/1/element/action/click",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"locators\":[\r\n        {\r\n            \"type\":\"ElementSelector\",\r\n            \"selector\":\".row-main-info\"\r\n        },\r\n        {\r\n            \"type\":\"ElementSelector\",\r\n            \"selector\":\".carousel-inner\"\r\n        },\r\n        {\r\n            \"type\":\"ElementSelector\",\r\n            \"selector\":\"h1.info-container__title\"\r\n        }\r\n    ]\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3333/wdio/applications/1/element/action/click",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3333",
+							"path": [
+								"wdio",
+								"applications",
+								"1",
+								"element",
+								"action",
+								"click"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,10 @@
         "declaration": true,
         "outDir": "./lib"
     },
+    "ts-node": {
+        "esm": true,
+        "experimentalSpecifierResolution": "node"
+    },
     "include": [
         "src/**/*",
         "src/**/*.json"


### PR DESCRIPTION
# PR Details

Added support to query pseudo elements and to scrolling from lib

## Description

Enabled to query pseudo elements values and to scroll into elements by using a method now implemented in the library.

## Related Issue

#99 

## Motivation and Context

In order to enhance the e2e test checks it would be convenient to enable the querying of pseudo selectors. Also it is convenient to add support to scrolling into elements from the library.

## How Has This Been Tested

Within the Beacon project

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] I have added tests to cover my changes (at least 1 spec for each widget with the same coverage as the master branch)
- [ ] All tests (new and existing) passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
