### PR TITLE
113 downgrade allure reporter version in commonjs compat branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "8.1.0-cjs.0",
+  "version": "8.1.0-cjs.1",
   "license": "MIT",
   "description": "Widgets to be use in the E2E Tests based in WDIO",
   "keywords": [


### PR DESCRIPTION
# PR Details

Downgraded allure reporter version to be compatible with wdio7.

## Description

In Modulab / HH / QL Platform currently using wdio7 with commonjs. It needs to be compatible due to the breaking changes.

## Related Issue
(https://github.com/systelab/systelab-components-wdio-test/issues/113)

## Motivation and Context

External compatibility

## How Has This Been Tested

Locally in ModulabGold Repo

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] I have added tests to cover my changes (at least 1 spec for each widget with the same coverage as the master branch)
- [x] All tests (new and existing) passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
