### PR TITLE
Feature 117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [9.1.2] - 2025-11-12
+
+### Changed
+
+* Separate setFeature and setDescription in TestIdentification to improve Allure reporting
+* Modify addExpectedResult in ReportUtility to set failed steps as failed in the generated allure-result.json 
+
 ## [9.1.1] - 2025-10-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ For a complete list of changes, bug fixes, and breaking changes, see the [CHANGE
 
 #### Latest Releases
 
+* **v9.1.2** (2025-11-12):
+
+    * Separate setFeature and setDescription in TestIdentification to improve Allure reporting
+    * Modify addExpectedResult in ReportUtility to set failed steps as failed in the generated allure-result.json
+
 * **v9.1.1** (2025-10-28):
 
     * Update right click to use Javascript implementation to be compatible with WebKitGTK on Jenkins

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components-wdio-test",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "license": "MIT",
   "type": "module",
   "description": "Widgets to be use in the E2E Tests based in WDIO",

--- a/src/utils/test-identification.util.ts
+++ b/src/utils/test-identification.util.ts
@@ -12,7 +12,10 @@ export class TestIdentification
 
     public static setDescription(description: string): void {
         ReportUtility.setDescription(description);
-        ReportUtility.setFeature(description);
+    }
+
+    public static setFeature(feature: string): void {
+        ReportUtility.setFeature(feature);
     }
 
     public static setAppVersion(appVersion: string): void {


### PR DESCRIPTION
# PR Details

Changes to make generated allure-result.json files compatible with systelab allure reporter:
- Separate setfeature and setdescription
- Modify addExpectedResult to set failed steps as failed (now all steps are set as passed even if they fail) 

## Description

Separate setFeature and setDescription in TestIdentification to improve Allure reporting
Modify addExpectedResult in ReportUtility to set failed steps as failed in the generated allure-result.json.

## Related Issue

#117 

## Motivation and Context

The changes need to be done so the generated allure-result.json will be compatible with systelab allure reporter

## How Has This Been Tested

Execute wdio test adding feature label --> the generated allure-result.json is as expected
Execute wdio tests with failed and passed steps --> the generated allure-result.json is as expected

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each widget)
- [ ] I have added tests to cover my changes (at least 1 spec for each widget with the same coverage as the master branch)
- [ ] All tests (new and existing) passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [X] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [X] Add the issue into the right [project](https://github.com/systelab/systelab-components-wdio-test/projects) with the proper status (In progress)
